### PR TITLE
update poster placeholder grid layout

### DIFF
--- a/src/features/movieDetails/styled.js
+++ b/src/features/movieDetails/styled.js
@@ -250,6 +250,8 @@ export const PosterPlaceholder = styled.div`
     width: 114px;
     height: 171px;
     font-size: 2rem;
+    grid-row: auto;
+    margin-bottom: 16px;
   }
 `;
 

--- a/src/features/movieDetails/styled.js
+++ b/src/features/movieDetails/styled.js
@@ -244,6 +244,7 @@ export const PosterPlaceholder = styled.div`
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  grid-row: span 2;
 
   @media (max-width: 768px) {
     width: 114px;


### PR DESCRIPTION
Dodano do zaślepki właściwość grid-row: span 2; używaną wcześniej przez plakat, co naprawia błąd wyświetlania opisu filmu w szczegółach.